### PR TITLE
Expansion of coins called and DB amendments

### DIFF
--- a/app/api/v1/endpoints.py
+++ b/app/api/v1/endpoints.py
@@ -15,7 +15,10 @@ def get_db():
     finally:
         db.close()
 
-@router.get("/coins", dependencies=[Depends(RateLimiter(times=20, minutes=1))])
+@router.get(
+    "/coins",
+    dependencies=[Depends(api_key_auth), Depends(RateLimiter(times=20, minutes=1))],
+)
 async def read_coins(db: Session = Depends(get_db)) -> list[dict]:
     """Fetch all coins and return them as JSON-serializable dicts."""
     coins = get_coins(db)

--- a/app/core/coins.py
+++ b/app/core/coins.py
@@ -1,0 +1,13 @@
+TRACKED_COINS = [
+    "bitcoin", "ethereum", "tether", "binancecoin", "solana",
+    "usd-coin", "xrp", "toncoin", "dogecoin", "cardano",
+    "avalanche-2", "shiba-inu", "polkadot", "chainlink", "tron",
+    "polygon", "litecoin", "bitcoin-cash", "uniswap", "cosmos",
+    "internet-computer", "stellar", "aptos", "ethereum-classic",
+    "filecoin", "immutable-x", "lido-dao", "cronos", "near",
+    "okb", "celestia", "render-token", "injective-protocol",
+    "quant-network", "vechain", "hedera-hashgraph", "kaspa",
+    "mantle", "theta-token", "monero", "algorand", "arbitrum",
+    "the-graph", "stacks", "maker", "aave", "sui",
+    "optimism", "flow"
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ os.environ.setdefault("COINMARKETCAP_KEY", "dummy")
 os.environ.setdefault("LUNARCRUSH_KEY", "dummy")
 os.environ.setdefault("API_KEYS", "testkey")
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("TESTING", "1")
 
 @pytest.fixture(scope="session", autouse=True)
 def env_settings():
@@ -18,6 +19,7 @@ def env_settings():
     mp.setenv("LUNARCRUSH_KEY", "dummy")
     mp.setenv("API_KEYS", "testkey")
     mp.setenv("REDIS_URL", "redis://localhost:6379/0")
+    mp.setenv("TESTING", "1")
     yield
     mp.undo()
 


### PR DESCRIPTION
Introduced a centralized list of tracked coins so market and sentiment jobs pull data for many currencies

Updated the scheduler jobs to iterate over this new list and skip coins not in it, ensuring only selected currencies are stored

Applied API key authentication along with rate limiting to the coins endpoint for improved security and controlled access