### PR TITLE
Add Kubernetes manifests

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: crypto-config
+data:
+  DATABASE_URL: postgresql://user:password@db:5432/crypto_db
+  COINGECKO_URL: https://api.coingecko.com/api/v3
+  REDIS_URL: redis://redis:6379/0
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crypto-secrets
+type: Opaque
+stringData:
+  COINMARKETCAP_KEY: ""
+  LUNARCRUSH_KEY: ""
+  API_KEYS: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crypto-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crypto-app
+  template:
+    metadata:
+      labels:
+        app: crypto-app
+    spec:
+      containers:
+      - name: crypto-app
+        image: tiangolo/uvicorn-gunicorn-fastapi:python3.10
+        command: ["uvicorn"]
+        args: ["app.main:app", "--host", "0.0.0.0", "--port", "80"]
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            configMapKeyRef:
+              name: crypto-config
+              key: DATABASE_URL
+        - name: COINGECKO_URL
+          valueFrom:
+            configMapKeyRef:
+              name: crypto-config
+              key: COINGECKO_URL
+        - name: REDIS_URL
+          valueFrom:
+            configMapKeyRef:
+              name: crypto-config
+              key: REDIS_URL
+        - name: COINMARKETCAP_KEY
+          valueFrom:
+            secretKeyRef:
+              name: crypto-secrets
+              key: COINMARKETCAP_KEY
+        - name: LUNARCRUSH_KEY
+          valueFrom:
+            secretKeyRef:
+              name: crypto-secrets
+              key: LUNARCRUSH_KEY
+        - name: API_KEYS
+          valueFrom:
+            secretKeyRef:
+              name: crypto-secrets
+              key: API_KEYS
+        ports:
+        - containerPort: 80

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: crypto-app
+spec:
+  type: ClusterIP
+  selector:
+    app: crypto-app
+  ports:
+  - port: 80
+    targetPort: 80


### PR DESCRIPTION
## Summary
- add basic Kubernetes deployment with ConfigMap and Secret
- expose the app via ClusterIP service

## Testing
- `pytest -q` *(fails: ConnectionError connecting to Redis)*

------
https://chatgpt.com/codex/tasks/task_b_68626d52d804832ca653b6914eeff430